### PR TITLE
Add "refund insufficent funds" config option

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -14,7 +14,8 @@ return {
         playSounds = true,
         showFooter = true,
         refundInvalidMetaname = true,
-        refundMissingMetaname = true
+        refundMissingMetaname = true,
+        refundInsufficentFunds = true
     },
     lang = {
         footer = "/pay <item>@%name% <amt>",

--- a/core/ShopState.lua
+++ b/core/ShopState.lua
@@ -134,7 +134,9 @@ function ShopState:handlePurchase(transaction, meta, sentMetaname, transactionCu
         amountPurchased = math.min(amountPurchased, purchasedProduct.maxQuantity)
     end
     if amountPurchased <= 0 then
-        refund(transactionCurrency, transaction.from, meta, transaction.value, self.config.lang.refundAtLeastOne, true)
+        if self.config.settings.refundInsufficentFunds then
+            refund(transactionCurrency, transaction.from, meta, transaction.value, self.config.lang.refundAtLeastOne, true)
+        end
         if self.eventHooks and self.eventHooks.failedPurchase then
             eventHook.execute(self.eventHooks.failedPurchase, transaction, transactionCurrency, purchasedProduct, self.config.lang.refundAtLeastOne)
         end

--- a/core/schemas.lua
+++ b/core/schemas.lua
@@ -15,7 +15,8 @@ local configSchema = {
         playSounds = "boolean",
         showFooter = "boolean",
         refundInvalidMetaname = "boolean",
-        refundMissingMetaname = "boolean"
+        refundMissingMetaname = "boolean",
+        refundInsufficentFunds = "boolean"
     },
     lang = {
         footer = "string",


### PR DESCRIPTION
Add the option to not refund buyer when the amount of krist paid is less than the amount needed to buy one of the desired product. This is a very evil option, but is the last refund type that doesn't either have a hook or config option to suppress it.